### PR TITLE
remove null value from default credential

### DIFF
--- a/src/containers/IssueCredentialStep.tsx
+++ b/src/containers/IssueCredentialStep.tsx
@@ -43,7 +43,6 @@ const IssueCredentialStepContainer: FC = () => {
           phoneNumber: '1234567890',
           homeAddress: {
             line1: '98765 Runner Rd.',
-            line2: null,
             city: 'Desert',
             state: 'AZ',
             zip: 12345,


### PR DESCRIPTION
[related ticket](https://trello.com/c/uKqi3mQn/979-null-values-are-not-serialized)
- quick fix to avoid a bug in the android sdk that happens when there are null values in a credential