### PR TITLE
prevent wrapping on whitespace/hyphens

### DIFF
--- a/src/components/Result.css
+++ b/src/components/Result.css
@@ -22,6 +22,7 @@
   padding-left: 10px;
   font-family: 'Courier New', Courier, monospace;
   overflow-x: scroll;
+  white-space: nowrap;
 }
 
 .result.disabled {


### PR DESCRIPTION
[Ticket](https://trello.com/c/VOfGBuxs/1040-prevent-deeplink-from-wrapping)

## Summary of changes
- adds `white-space: nowrap` to result box to prevent wrapping on whitespace and/or hyphens

## Screenshots

<img width="380" alt="Screen Shot 2021-02-04 at 6 35 06 PM" src="https://user-images.githubusercontent.com/12288236/106982022-0a9efe00-6718-11eb-8de6-c4c2f551398b.png">
