### PR TITLE
fix typo, update presentation display

### DIFF
--- a/src/components/Intro.tsx
+++ b/src/components/Intro.tsx
@@ -28,7 +28,7 @@ const Intro: FC = () => {
       <Description>
         <LatoLight>
           To begin, install the Developer Demo mobile app <a href=''>here</a>.
-          It will generate a usename for you.
+          It will generate a username for you.
         </LatoLight>
       </Description>
     </section>

--- a/src/components/VerifyStep.tsx
+++ b/src/components/VerifyStep.tsx
@@ -4,10 +4,10 @@ import Step from './Step';
 import StepLeft from './StepLeft';
 import StepRight from './StepRight';
 import HardcodedInput from './HardcodedInput';
-import HardcodedJsonInput from './HardcodedJsonInput';
 import Result from './Result';
 import { Presentation } from '@unumid/types';
 import step6Image from '../assets/step6.png';
+import JsonResult from './JsonResult';
 
 export interface VerifyStepProps {
   verifierDid?: string;
@@ -64,10 +64,9 @@ const VerifyStep: FC<VerifyStepProps> = ({
           value={verifierDid}
           description={verifierDidDescription}
         />
-        <HardcodedJsonInput
-          inputId='presentation'
-          labelText='Presentation'
-          value={JSON.stringify(presentation)}
+        <JsonResult
+          label='Presentation'
+          value={presentation}
           description={presentationDescription}
         />
       </StepLeft>


### PR DESCRIPTION
[fix typo](https://trello.com/c/aZv23v84/1709-typo-last-paragraph-of-intro-usename-username)
[update presentation display](https://trello.com/c/1PXJyMhX/1711-prettify-json-in-presentation-block)

## Screenshots
Intro
<img width="1262" alt="Screen Shot 2021-08-02 at 5 03 40 PM" src="https://user-images.githubusercontent.com/12288236/127939042-aebdf6ed-33c2-4ef2-8a15-56fa1c2b8864.png">
Presentation
<img width="1237" alt="Screen Shot 2021-08-02 at 5 03 23 PM" src="https://user-images.githubusercontent.com/12288236/127939033-3a999234-a038-478e-b39a-82397738e389.png">

