### PR TITLE
remove unpublished lint packages and disable lint in test script

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,9 @@
 {
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "import", "jest"],
-  "extends": ["semistandard-react"],
   "rules": {
     "no-use-before-define": "off",
-    "@typescript-eslint/no-use-before-define": ["error"],
-    "semistandard-react/prop-types": "off"
+    "@typescript-eslint/no-use-before-define": ["error"]
   },
   "settings": {
     "import/extensions": [".js",".jsx",".ts",".tsx"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,10 +41,8 @@
         "@typescript-eslint/parser": "^4.10.0",
         "babel-eslint": "^10.1.0",
         "eslint": "^7.15.0",
-        "eslint-config-semistandard-react": "^4.2.0",
         "eslint-import-resolver-typescript": "^2.3.0",
         "eslint-plugin-jest": "^24.1.3",
-        "eslint-plugin-semistandard-react": "^4.1.0",
         "react-test-renderer": "^17.0.1"
       }
     },
@@ -8031,17 +8029,6 @@
         }
       }
     },
-    "node_modules/eslint-config-semistandard-react": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-semistandard-react/-/eslint-config-semistandard-react-4.2.0.tgz",
-      "integrity": "sha512-lSjvk76SWKJSb3M2Ng+3ZRykFyucyfMYbKjI20egeGyWHRyU5xC+vEL5r5FBJcggCq2JBWqbYDnWZtyD8td7Rg==",
-      "dev": true,
-      "peerDependencies": {
-        "babel-eslint": "^8.0.0",
-        "eslint": "^4.0.0",
-        "eslint-plugin-semistandard-react": "^4.1.0"
-      }
-    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
@@ -8215,48 +8202,6 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
       }
     },
-    "node_modules/eslint-plugin-node": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz",
-      "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
-      "dev": true,
-      "dependencies": {
-        "ignore": "^3.3.6",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.3",
-        "semver": "5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": ">=3.1.0"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/ignore": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-      "dev": true
-    },
-    "node_modules/eslint-plugin-node/node_modules/semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/eslint-plugin-promise": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
-      "integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/eslint-plugin-react": {
       "version": "7.24.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.24.0.tgz",
@@ -8314,31 +8259,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/eslint-plugin-semistandard-react": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-semistandard-react/-/eslint-plugin-semistandard-react-4.1.0.tgz",
-      "integrity": "sha512-mOVb+t00rZrn4Y3k38hre+ONHqe7/ldLvto9WF1SdnAON+/jRDr26H1xVNDuJgveQ4Y7FhhbY05ABWtemylqYw==",
-      "dev": true,
-      "dependencies": {
-        "eslint-plugin-import": "^2.7.0",
-        "eslint-plugin-node": "^5.2.0",
-        "eslint-plugin-promise": "^3.5.0",
-        "eslint-plugin-react": "^7.4.0",
-        "eslint-plugin-standard": "^3.0.1"
-      },
-      "peerDependencies": {
-        "eslint": "^4.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-standard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz",
-      "integrity": "sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==",
-      "dev": true,
-      "peerDependencies": {
-        "eslint": ">=3.19.0"
       }
     },
     "node_modules/eslint-plugin-testing-library": {
@@ -28781,13 +28701,6 @@
         "confusing-browser-globals": "^1.0.10"
       }
     },
-    "eslint-config-semistandard-react": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-semistandard-react/-/eslint-config-semistandard-react-4.2.0.tgz",
-      "integrity": "sha512-lSjvk76SWKJSb3M2Ng+3ZRykFyucyfMYbKjI20egeGyWHRyU5xC+vEL5r5FBJcggCq2JBWqbYDnWZtyD8td7Rg==",
-      "dev": true,
-      "requires": {}
-    },
     "eslint-import-resolver-node": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
@@ -28924,38 +28837,6 @@
         "language-tags": "^1.0.5"
       }
     },
-    "eslint-plugin-node": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz",
-      "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
-      "dev": true,
-      "requires": {
-        "ignore": "^3.3.6",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.3",
-        "semver": "5.3.0"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "3.3.10",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        }
-      }
-    },
-    "eslint-plugin-promise": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
-      "integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==",
-      "dev": true
-    },
     "eslint-plugin-react": {
       "version": "7.24.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.24.0.tgz",
@@ -28998,26 +28879,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
       "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-      "requires": {}
-    },
-    "eslint-plugin-semistandard-react": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-semistandard-react/-/eslint-plugin-semistandard-react-4.1.0.tgz",
-      "integrity": "sha512-mOVb+t00rZrn4Y3k38hre+ONHqe7/ldLvto9WF1SdnAON+/jRDr26H1xVNDuJgveQ4Y7FhhbY05ABWtemylqYw==",
-      "dev": true,
-      "requires": {
-        "eslint-plugin-import": "^2.7.0",
-        "eslint-plugin-node": "^5.2.0",
-        "eslint-plugin-promise": "^3.5.0",
-        "eslint-plugin-react": "^7.4.0",
-        "eslint-plugin-standard": "^3.0.1"
-      }
-    },
-    "eslint-plugin-standard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz",
-      "integrity": "sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==",
-      "dev": true,
       "requires": {}
     },
     "eslint-plugin-testing-library": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "yarn lint && react-scripts test",
+    "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint \"src/**/*.ts*\""
   },
@@ -62,10 +62,8 @@
     "@typescript-eslint/parser": "^4.10.0",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.15.0",
-    "eslint-config-semistandard-react": "^4.2.0",
     "eslint-import-resolver-typescript": "^2.3.0",
     "eslint-plugin-jest": "^24.1.3",
-    "eslint-plugin-semistandard-react": "^4.1.0",
     "react-test-renderer": "^17.0.1"
   }
 }


### PR DESCRIPTION
[ticket](https://trello.com/c/kx7yfp8C/1771-update-lint-configs-and-or-disable-linting-in-ci)

`eslint-config-semistandard-react` and `eslint-plugin-semistandard-react` packages were unpublished from npm this morning. removing them and disabling lint in ci for now, will figure out a new lint config when I get back from vacation